### PR TITLE
Added option to save to full paths

### DIFF
--- a/scripts/label_all_tokens.py
+++ b/scripts/label_all_tokens.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import pickle
 
 from tqdm.auto import tqdm
@@ -32,10 +33,14 @@ def main():
         default="delphi-suite/delphi-llama2-100k",
         required=False,
     )
+    parser.add_argument(
+        "--output",
+        help="Output path name. Must include at least output file name.",
+        default="labelled_token_ids_dict.pkl",
+    )
     args = parser.parse_args()
 
     # Access command-line arguments
-
     model_name = args.model_name
 
     print("\n", " LABEL ALL TOKENS ".center(50, "="), "\n")
@@ -86,8 +91,13 @@ def main():
         labelled_token_ids_dict[token_id] = labels[0][0]
 
     # Save the labelled tokens to a file
-    filename = "labelled_token_ids_dict.pkl"
-    filepath = STATIC_ASSETS_DIR.joinpath(filename)
+    if os.path.split(args.output)[0] == "":
+        filepath = STATIC_ASSETS_DIR.joinpath(args.output)
+        print(f"Outputting file {args.output} to path {filepath}")
+    else:
+        filepath = os.path.expandvars(args.output)
+        print(f"Outputting to path {filepath}")
+
     with open(f"{filepath}", "wb") as f:
         pickle.dump(labelled_token_ids_dict, f)
 

--- a/scripts/label_all_tokens.py
+++ b/scripts/label_all_tokens.py
@@ -34,8 +34,8 @@ def main():
         required=False,
     )
     parser.add_argument(
-        "--output",
-        help="Output path name. Must include at least output file name.",
+        "--output_path",
+        help="Output path name.",
         default="labelled_token_ids_dict.pkl",
     )
     args = parser.parse_args()
@@ -65,7 +65,7 @@ def main():
     # Save the list of all tokens to a file
     filename = "all_tokens_list.txt"
     filepath = STATIC_ASSETS_DIR.joinpath(filename)
-    with open(f"{filepath}", "w", encoding="utf-8") as f:
+    with open(str(filepath), "w", encoding="utf-8") as f:
         f.write(tokens_str)
 
     print(f"Saved the list of all tokens to:\n\t{filepath}\n")
@@ -91,14 +91,14 @@ def main():
         labelled_token_ids_dict[token_id] = labels[0][0]
 
     # Save the labelled tokens to a file
-    if os.path.split(args.output)[0] == "":
-        filepath = STATIC_ASSETS_DIR.joinpath(args.output)
-        print(f"Outputting file {args.output} to path {filepath}")
+    if os.path.dirname(args.output_path) == "":
+        filepath = os.path.join(os.getcwd(), args.output_path)
     else:
-        filepath = os.path.expandvars(args.output)
-        print(f"Outputting to path {filepath}")
+        filepath = args.output_path
 
-    with open(f"{filepath}", "wb") as f:
+    filepath = os.path.abspath(filepath)
+
+    with open(filepath, "wb") as f:
         pickle.dump(labelled_token_ids_dict, f)
 
     print(f"Saved the labelled tokens to:\n\t{filepath}\n")
@@ -106,7 +106,7 @@ def main():
     # sanity check that The pickled and the original dict are the same
     print("Sanity check ...", end="")
     # load pickle
-    with open(f"{filepath}", "rb") as f:
+    with open(filepath, "rb") as f:
         pickled = pickle.load(f)
     # compare
     assert labelled_token_ids_dict == pickled

--- a/scripts/map_tokens.py
+++ b/scripts/map_tokens.py
@@ -11,14 +11,40 @@ from delphi.eval.utils import load_validation_dataset
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="")
     parser.add_argument(
-        "dataset_name", help="Dataset from huggingface to run token_map on"
+        "dataset_name",
+        help="Dataset from huggingface to run token_map on. Must be tokenized.",
+        default="delphi-suite/v0-tinystories-v2-clean-tokenized",
     )
-    parser.add_argument("--output", help="Output file name", default="token_map.pkl")
+    parser.add_argument(
+        "--output",
+        help="Output path name. Must include at least output file name.",
+        default="token_map.pkl",
+    )
     args = parser.parse_args()
+
+    print("\n", " MAP TOKENS TO POSITIONS ".center(50, "="), "\n")
+    print(f"You chose the dataset: {args.dataset_name}\n")
+
+    if os.path.split(args.output)[0] == "":
+        filepath = STATIC_ASSETS_DIR.joinpath(args.output)
+        print(f"Outputting file {args.output} to path\n\t{filepath}\n")
+    else:
+        filepath = os.path.expandvars(args.output)
+        print(f"Outputting to path\n\t{filepath}\n")
 
     dataset = load_validation_dataset(args.dataset_name)
 
     mapping = token_map(dataset)
 
-    with open(f"{STATIC_ASSETS_DIR}/{args.output}", "wb") as f:
+    with open(f"{filepath}", "wb") as f:
         pickle.dump(mapping, file=f)
+
+    print(f"Token map saved to\n\t{filepath}\n")
+    print("Sanity check ... ", end="")
+
+    with open(f"{filepath}", "rb") as f:
+        pickled = pickle.load(f)
+
+    assert mapping == pickled
+    print("completed.")
+    print(" END ".center(50, "="))

--- a/scripts/map_tokens.py
+++ b/scripts/map_tokens.py
@@ -11,40 +11,14 @@ from delphi.eval.utils import load_validation_dataset
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="")
     parser.add_argument(
-        "dataset_name",
-        help="Dataset from huggingface to run token_map on. Must be tokenized.",
-        default="delphi-suite/v0-tinystories-v2-clean-tokenized",
+        "dataset_name", help="Dataset from huggingface to run token_map on"
     )
-    parser.add_argument(
-        "--output",
-        help="Output path name. Must include at least output file name.",
-        default="token_map.pkl",
-    )
+    parser.add_argument("--output", help="Output file name", default="token_map.pkl")
     args = parser.parse_args()
-
-    print("\n", " MAP TOKENS TO POSITIONS ".center(50, "="), "\n")
-    print(f"You chose the dataset: {args.dataset_name}\n")
-
-    if os.path.split(args.output)[0] == "":
-        filepath = STATIC_ASSETS_DIR.joinpath(args.output)
-        print(f"Outputting file {args.output} to path\n\t{filepath}\n")
-    else:
-        filepath = os.path.expandvars(args.output)
-        print(f"Outputting to path\n\t{filepath}\n")
 
     dataset = load_validation_dataset(args.dataset_name)
 
     mapping = token_map(dataset)
 
-    with open(f"{filepath}", "wb") as f:
+    with open(f"{STATIC_ASSETS_DIR}/{args.output}", "wb") as f:
         pickle.dump(mapping, file=f)
-
-    print(f"Token map saved to\n\t{filepath}\n")
-    print("Sanity check ... ", end="")
-
-    with open(f"{filepath}", "rb") as f:
-        pickled = pickle.load(f)
-
-    assert mapping == pickled
-    print("completed.")
-    print(" END ".center(50, "="))


### PR DESCRIPTION
Address issue #42 

Added options to script to allow users to save to full path instead of the fixed static dir. Also modified the `scripts/map_tokens.py` file for consistency in scripts.

I noticed that the part to allow for this save option is similar across scripts. Should I make a general function for this? 