### PR TITLE
Added token selector

### DIFF
--- a/requirements-nocuda.txt
+++ b/requirements-nocuda.txt
@@ -21,6 +21,8 @@ wandb==0.16.3
 spacy==3.7.2
 pandas==1.3.4
 dacite==1.8.1
+panel==1.4.0
+jupyter_bokeh==4.0.1
 
 # temporarily installing transformers from main until 4.39.0 comes out (for mamba support)
 transformers @ git+https://github.com/huggingface/transformers@main

--- a/src/delphi/eval/vis.py
+++ b/src/delphi/eval/vis.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import cast
 
+import panel as pn
 import torch
 from IPython.core.display import HTML
 from IPython.core.display_functions import display
@@ -138,3 +139,18 @@ def vis_sample_prediction_probs(
     """
     display(HTML(html_str))
     return html_str
+
+
+def token_selector(
+    vocab_map: dict[str, int]
+) -> tuple[pn.widgets.MultiChoice, list[int]]:
+    tokens = list(vocab_map.keys())
+    token_selector = pn.widgets.MultiChoice(name="Tokens", options=tokens)
+    token_ids = [vocab_map[token] for token in cast(list[str], token_selector.value)]
+
+    def update_tokens(event):
+        token_ids.clear()
+        token_ids.extend([vocab_map[token] for token in event.new])
+
+    token_selector.param.watch(update_tokens, "value")
+    return token_selector, token_ids


### PR DESCRIPTION
Adds the function to make token selector from tokenizer's vocab. Basically, the input should be a `dict[str, int]` that you can get from calling `tokenizer.get_vocab()`. We could also change the input to the tokenizer instead, but it's like that for now.

The function returns two thing, the first thing is the actual widget itself. If you want the string tokens from the widget, you can call `widget.value`. The second thing is a list of tokens ids that correspond to the selected tokens that are continually updated.