### PR TITLE
Fix training data shifting bug

### DIFF
--- a/src/delphi/train/train_step.py
+++ b/src/delphi/train/train_step.py
@@ -56,15 +56,15 @@ def train_step(
 
 def accumulate_gradients(
     model: PreTrainedModel,
-    batches: Iterable[tuple[torch.Tensor, torch.Tensor]],
+    batches: Iterable[torch.Tensor],
     num_batches: int,
 ) -> float:
     """
     Accumulate gradients over multiple batches as if they were a single batch
     """
     total_loss = 0.0
-    for X, Y in batches:
-        loss = model(X, labels=Y, return_dict=True).loss / num_batches
+    for X in batches:
+        loss = model(X, labels=X, return_dict=True).loss / num_batches
         total_loss += loss.item()
         loss.backward()
     return total_loss

--- a/src/delphi/train/utils.py
+++ b/src/delphi/train/utils.py
@@ -161,14 +161,13 @@ def get_xy_batch(
     batch_num: int,
     feature_name: str,
     device: torch.device,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     """Get a batch of data from a dataset given a batch number and indices"""
     start = batch_num * batch_size
     end = (batch_num + 1) * batch_size
     batch_indices = indices[start:end]
     data = dataset[batch_indices][feature_name].to(device)
-    # *ForCausalLM models do shifting internally, so input and labels are the same
-    return data, data
+    return data
 
 
 def gen_minibatches(
@@ -179,7 +178,7 @@ def gen_minibatches(
     indices: list[int],
     device: torch.device,
     feature_name: str,
-) -> Generator[tuple[torch.Tensor, torch.Tensor], None, None]:
+) -> Generator[torch.Tensor, None, None]:
     """
     Generate minibatches from a dataset given a step and indices
     """
@@ -227,8 +226,8 @@ def estimate_loss(
             device=device,
             feature_name=feature_name,
         )
-        for k, (X, Y) in enumerate(minibatches):
-            loss = model(X, labels=Y, return_dict=True).loss
+        for k, X in enumerate(minibatches):
+            loss = model(X, labels=X, return_dict=True).loss
             losses[k] = loss.item()
         out[split] = losses.mean().item()
     model.train()

--- a/src/delphi/train/utils.py
+++ b/src/delphi/train/utils.py
@@ -167,7 +167,8 @@ def get_xy_batch(
     end = (batch_num + 1) * batch_size
     batch_indices = indices[start:end]
     data = dataset[batch_indices][feature_name].to(device)
-    return data[:, :-1], data[:, 1:]
+    # *ForCausalLM models do shifting internally, so input and labels are the same
+    return data, data
 
 
 def gen_minibatches(

--- a/tests/train/test_train_step.py
+++ b/tests/train/test_train_step.py
@@ -86,7 +86,7 @@ def test_basic_reproducibility(dataset, model):
 
     assert torch.isclose(
         params[[1000, 2000, 3000]],
-        torch.tensor([-0.01782517, -0.00771354, 0.03517739]),
+        torch.tensor([-0.01780166, -0.00762226, 0.03532362]),
     ).all()
 
 


### PR DESCRIPTION
~Currently the minimal viable fix. Further simplification is possible and desirable.~

Fixes and simplifies training data generation. There's no longer a separate label tensor, since *ForCausalLM models shift the labels internally (for some reason)